### PR TITLE
📝 Add METADATA.yaml for working group visibility on amp.dev

### DIFF
--- a/METADATA.yaml
+++ b/METADATA.yaml
@@ -1,0 +1,21 @@
+title: Performance
+description: wg-performance Working Group is responsible for monitoring and improving AMP's load and runtime performance for compliant documents.
+facilitator:
+  login: kristoferbaxter
+  name: Kristofer Baxter
+members:
+  - login: erwinmombay
+    name: Erwin Mombay
+  - login: alanorozco
+    name: Alan Orozco
+communication:
+  - channel: slack
+    name: Slack
+    content:
+      - item: "The Performance Working Group members will use `#wg-performance` channel on AMP's Slack ([signup](https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877)) for real-time discussion. The channel is open to anyone, regardless of membership in Performance working group."
+  - channel: github
+    name: GitHub
+    content:
+      - item: "Performance Working Group will post **Status Updates** every two weeks as an issue labeled with `Type: Status Update` in this repository."
+      - item: "Performance Working Group will post **Announcements and Notices** regarding events as an issue labeled with `Type: Event` in this repository."
+      - item: "Performance Working Group will post **Quarterly Roadmap** as an issue labeled with `Type: Roadmap` in this repository."

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Facilitator: [@kristoferbaxter](https://github.com/kristoferbaxter)
 Github team https://github.com/orgs/ampproject/teams/wg-performance also includes UI WG members.
 
 # Communication Channels
-- Performance Working Group members will use `#wg-performance` channel on AMP's Slack ([signup](https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877)) for real-time discussion. The channel is open to anyone, regardless of membership in UI working group.
+- Performance Working Group members will use `#wg-performance` channel on AMP's Slack ([signup](https://docs.google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877)) for real-time discussion. The channel is open to anyone, regardless of membership in Performance working group.
 - Performance Working Group will post **Status Updates** every two weeks as an issue labeled with `Type: Status Update` in this repository.
 - Performance Working Group will post **Announcements and Notices** regarding events as an issue labeled with `Type: Event` in this repository.
 - Performance Working Group will post **Quarterly Roadmap** as an issue labeled with `Type: Roadmap` in this repository.
@@ -19,7 +19,7 @@ Github team https://github.com/orgs/ampproject/teams/wg-performance also include
 
 Any bugs or feature requests related to AMP should NOT be filed in this repository and https://github.com/ampproject/amphtml/issues should be used instead.
 
-`@ampproject/wg-performance` can be used to mention the UI Working Group in issues and PRs.
+`@ampproject/wg-performance` can be used to mention the Performance Working Group in issues and PRs.
 
 # Code of Conduct
 The Performance Working Group follows the [AMP open source project code of conduct](https://github.com/ampproject/meta/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This is part of the effort of making the AMP Project working groups more visible. By adding a METADATA.yaml file to this repository relevant information about the working group (facilitator, team members, channels, etc.) is easily importable by amp.dev's build process and makes it possible to build an AMP page for each working group.

See ampproject/amp.dev#1699 and ampproject/amp.dev#3065 for more history.

/cc @pbakaus, @sebastianbenz